### PR TITLE
Update ScareCrow.go

### DIFF
--- a/ScareCrow.go
+++ b/ScareCrow.go
@@ -117,7 +117,7 @@ func main() {
 		log.Fatal("Error: Please provide the a HTA filename to store the loader in")
 	}
 
-	if (opt.CommandLoader == "hta" || opt.CommandLoader == "macro") && (opt.LoaderType == "binary" || opt.LoaderType == "dll") { {
+	if (opt.CommandLoader == "hta" || opt.CommandLoader == "macro") && (opt.LoaderType == "binary" || opt.LoaderType == "dll") {
 		log.Fatal("Error: Binary and DLL loaders are not compatable with this delivery command")
 	}
 


### PR DESCRIPTION
Current build throws this error when trying to `go build ScareCrow.go`

![Pasted image 20210422171258](https://user-images.githubusercontent.com/51839088/115786243-895a1d80-a38e-11eb-8293-07a9af203b42.png)

Fixed by removing extra curly-brace :) 

Smallest PR ever?
